### PR TITLE
Bugfix/improve linux compatibility

### DIFF
--- a/bike-lending-app/pom.xml
+++ b/bike-lending-app/pom.xml
@@ -63,6 +63,11 @@
 			<version>8.3.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>2.7.3</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>2.23.1</version>

--- a/bike-lending-app/sql/create-bikes.sql
+++ b/bike-lending-app/sql/create-bikes.sql
@@ -1,11 +1,11 @@
 /* DELETE 'bikesDB' database*/
-DROP SCHEMA IF EXISTS bikesDB;
+DROP SCHEMA IF EXISTS bikesdb;
 /* DELETE USER 'spq' AT LOCAL SERVER*/
 DROP USER IF EXISTS 'spq'@'localhost';
 
 /* CREATE 'messagesDB' DATABASE */
-CREATE SCHEMA bikesDB;
+CREATE SCHEMA bikesdb;
 /* CREATE THE USER 'spq' AT LOCAL SERVER WITH PASSWORD 'spq' */
 CREATE USER IF NOT EXISTS 'spq'@'localhost' IDENTIFIED BY 'spq';
 
-GRANT ALL ON bikesDB.* TO 'spq'@'localhost';
+GRANT ALL ON bikesdb.* TO 'spq'@'localhost';


### PR DESCRIPTION
Hi @alru28,
These changes make the code mostly compile on linux. Please verify that this doesn't break the compilation on Windows.

There is one more unresolved issue related to using MariaDB that prevents compilation on linux.
In `bike-lending-app/src/main/resources/datanucleus.properties` the JDBC driver is specified as either `mysql` or `mariadb` with the latter necessary for successful compilation when using MariaDB. Otherwise the following error occurs:

```
An error was encountered creating a PersistenceManagerFactory : Failed initialising database. Please check that your database JDBC driver is accessible, and the database URL and username/password are correct. Exception : Cannot invoke "org.datanucleus.store.rdbms.adapter.DatastoreAdapter.supportsOption(String)" because "dba" is null
```
